### PR TITLE
Fix anchor font sizes

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -84,7 +84,6 @@
 *::after {
   box-sizing: border-box;
   margin: 0;
-  font-size: 16px;  /* Definition for 1rem */
 }
 
 body {


### PR DESCRIPTION
By dropping the font size from universal selector.  We already specify a base font size on body, so it's unnecessary here.  This applies size specification individually to all elements, which causes `a` to override parent container settings.  Removing it allows elements to scale with parent container.